### PR TITLE
コマンドライン引数から値を取得する時に空だった場合処理しない

### DIFF
--- a/subcmd/deploy/deploy.go
+++ b/subcmd/deploy/deploy.go
@@ -159,11 +159,15 @@ func (c *Deploy) Run(args []string) int {
 	if err != nil {
 		log.Fatal(err)
 	}
-	baseStr, err := lib.Embedde(string(baseConfBinary), *outerVals)
-	if err != nil {
-		log.Fatal(err)
+
+	if *outerVals != "" {
+		baseStr, err := lib.Embedde(string(baseConfBinary), *outerVals)
+		if err != nil {
+			log.Fatal(err)
+		}
+		baseConfBinary = []byte(baseStr)
 	}
-	baseConfBinary = []byte(baseStr)
+
 	if externalList != nil {
 		c, err := readConf(baseConfBinary, externalList)
 		if err != nil {


### PR DESCRIPTION
コマンドライン引数から上書き用の値を取得した時
値が空だった場合は何もしない