### PR TITLE
vault viewする時開いたファイルを書き換えない

### DIFF
--- a/subcmd/vault_view/vault_view.go
+++ b/subcmd/vault_view/vault_view.go
@@ -1,6 +1,7 @@
 package vview
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -106,15 +107,9 @@ func (c *VaultView) Run(args []string) int {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	file, err := ioutil.TempFile(os.TempDir(), "pnzr")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.Remove(file.Name())
-	file.Write(plain)
 
-	cmd := exec.Command("less", file.Name())
-	cmd.Stdin = os.Stdin
+	cmd := exec.Command("less")
+	cmd.Stdin = bytes.NewReader(plain)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
# やったこと

```
復号 -> less -> 暗号化
```
としてたがファイルが書き換わってしまうので
```
復号->less
```
にした
temp fileを使わずにメモリの上だけに復号したファイルを載せるので `ctrl+c` しても復号したファイルが残らない

close #45 