### PR TITLE
ECSテスト

### DIFF
--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	_ "fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/jobtalk/pnzr/lib/iface"
+	"github.com/jobtalk/pnzr/lib/setting"
+)
+
+func TestDeploy(t *testing.T) {
+	taskDefinition := &ecs.RegisterTaskDefinitionInput{}
+	service := &ecs.CreateServiceInput{}
+
+	// Settings
+	onlyService := setting.Setting{
+		ECS: &setting.ECS{Service: service},
+	}
+	onlyTaskDefinition := setting.Setting{
+		ECS: &setting.ECS{TaskDefinition: taskDefinition},
+	}
+	both := setting.Setting{
+		ECS: &setting.ECS{
+			Service:        service,
+			TaskDefinition: taskDefinition,
+		},
+	}
+
+	// onlyService
+	{
+		deploy, isRegisterTaskDefinitionCalled, isUpsertServiceCalled := mockDeploy()
+		deploy.Deploy(&onlyService)
+		if *isRegisterTaskDefinitionCalled {
+			t.Fatalf("RegisterTaskDefinition should not be called")
+		}
+		if !*isUpsertServiceCalled {
+			t.Fatalf("UpsertService should be called")
+		}
+	}
+
+	// onlyTaskDefinition
+	{
+		deploy, isRegisterTaskDefinitionCalled, isUpsertServiceCalled := mockDeploy()
+		deploy.Deploy(&onlyTaskDefinition)
+		if !*isRegisterTaskDefinitionCalled {
+			t.Fatalf("RegisterTaskDefinition should be called")
+		}
+		if *isUpsertServiceCalled {
+			t.Fatalf("UpsertService should not be called")
+		}
+	}
+
+	// both
+	{
+		deploy, isRegisterTaskDefinitionCalled, isUpsertServiceCalled := mockDeploy()
+		deploy.Deploy(&both)
+		if !*isRegisterTaskDefinitionCalled {
+			t.Fatalf("RegisterTaskDefinition should be called")
+		}
+		if !*isUpsertServiceCalled {
+			t.Fatalf("UpsertService should not be called")
+		}
+	}
+}
+
+type mockedECS struct {
+	iface.ECSAPI
+	registerTaskDefinition func(*ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
+	upsertService          func(*ecs.CreateServiceInput) (interface{}, error)
+}
+
+func (m mockedECS) RegisterTaskDefinition(in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+	m.registerTaskDefinition(in)
+	return nil, nil
+}
+
+func (m mockedECS) UpsertService(in *ecs.CreateServiceInput) (interface{}, error) {
+	m.upsertService(in)
+	return nil, nil
+}
+
+func mockDeploy() (*DeployDeps, *bool, *bool) {
+	isRegisterTaskDefinitionCalled := false
+	isUpsertServiceCalled := false
+	ecs := mockedECS{
+		registerTaskDefinition: func(in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+			isRegisterTaskDefinitionCalled = true
+			return nil, nil
+		},
+		upsertService: func(in *ecs.CreateServiceInput) (interface{}, error) {
+			isUpsertServiceCalled = true
+			return nil, nil
+		},
+	}
+	return &DeployDeps{ecs: ecs}, &isRegisterTaskDefinitionCalled, &isUpsertServiceCalled
+}

--- a/lib/ecs.go
+++ b/lib/ecs.go
@@ -32,7 +32,7 @@ func (e *ECS) UpsertService(createServiceInput *ecs.CreateServiceInput) (interfa
 	if createServiceInput.Cluster == nil {
 		createServiceInput.Cluster = aws.String("default")
 	}
-	ok, err := e.isExistService(*createServiceInput.Cluster, *createServiceInput.ServiceName)
+	ok, err := e.serviceExists(*createServiceInput.Cluster, *createServiceInput.ServiceName)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (e *ECS) ListServices(params *ecs.ListServicesInput) (*ecs.ListServicesOutp
 	return ret, nil
 }
 
-func (e *ECS) isExistService(clusetrName string, serviceName string) (bool, error) {
+func (e *ECS) serviceExists(clusetrName string, serviceName string) (bool, error) {
 	listInput := &ecs.ListServicesInput{
 		Cluster: aws.String(clusetrName),
 	}

--- a/lib/ecs.go
+++ b/lib/ecs.go
@@ -28,6 +28,27 @@ func (e *ECS) RegisterTaskDefinition(registerTaskDefinitionInput *ecs.RegisterTa
 	return e.svc.RegisterTaskDefinition(registerTaskDefinitionInput)
 }
 
+func (e *ECS) UpsertService(createServiceInput *ecs.CreateServiceInput) (interface{}, error) {
+	if createServiceInput.Cluster == nil {
+		createServiceInput.Cluster = aws.String("default")
+	}
+	ok, err := e.isExistService(*createServiceInput.Cluster, *createServiceInput.ServiceName)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return e.svc.CreateService(createServiceInput)
+	}
+
+	updateServiceInput := &ecs.UpdateServiceInput{}
+	updateServiceInput.Cluster = createServiceInput.Cluster
+	updateServiceInput.DeploymentConfiguration = createServiceInput.DeploymentConfiguration
+	updateServiceInput.DesiredCount = createServiceInput.DesiredCount
+	updateServiceInput.Service = createServiceInput.ServiceName
+	updateServiceInput.TaskDefinition = createServiceInput.TaskDefinition
+	return e.svc.UpdateService(updateServiceInput)
+}
+
 func (e *ECS) ListServices(params *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
 	var (
 		ret     = &ecs.ListServicesOutput{}
@@ -45,50 +66,16 @@ func (e *ECS) ListServices(params *ecs.ListServicesInput) (*ecs.ListServicesOutp
 	return ret, nil
 }
 
-func (e *ECS) CreateService(createServiceInput *ecs.CreateServiceInput) (*ecs.CreateServiceOutput, error) {
-	return e.svc.CreateService(createServiceInput)
-}
-
-func (e *ECS) UpdateService(updateServiceInput *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
-	return e.svc.UpdateService(updateServiceInput)
-}
-
-func UpsertService(awsConfig *aws.Config, createServiceInput *ecs.CreateServiceInput) (interface{}, error) {
-	ecsClient := NewECS(awsConfig)
-	if len(createServiceInput.LoadBalancers) != 0 && targetGroupARN != nil {
-		createServiceInput.LoadBalancers[0].TargetGroupArn = targetGroupARN
-	}
-	if createServiceInput.Cluster == nil {
-		createServiceInput.Cluster = aws.String("default")
-	}
-	ok, err := IsExistService(awsConfig, *createServiceInput.Cluster, *createServiceInput.ServiceName)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return ecsClient.CreateService(createServiceInput)
-	}
-
-	updateServiceInput := &ecs.UpdateServiceInput{}
-	updateServiceInput.Cluster = createServiceInput.Cluster
-	updateServiceInput.DeploymentConfiguration = createServiceInput.DeploymentConfiguration
-	updateServiceInput.DesiredCount = createServiceInput.DesiredCount
-	updateServiceInput.Service = createServiceInput.ServiceName
-	updateServiceInput.TaskDefinition = createServiceInput.TaskDefinition
-	return ecsClient.UpdateService(updateServiceInput)
-}
-
-func IsExistService(awsConfig *aws.Config, clusetrName string, serviceName string) (bool, error) {
-	ecsClient := NewECS(awsConfig)
+func (e *ECS) isExistService(clusetrName string, serviceName string) (bool, error) {
 	listInput := &ecs.ListServicesInput{
 		Cluster: aws.String(clusetrName),
 	}
-	result, err := ecsClient.ListServices(listInput)
+	result, err := e.ListServices(listInput)
 	if err != nil {
 		return false, err
 	}
 	for _, v := range result.ServiceArns {
-		s, err := ParseArn(v)
+		s, err := parseArn(v)
 		if err != nil {
 			return false, err
 		}
@@ -99,7 +86,7 @@ func IsExistService(awsConfig *aws.Config, clusetrName string, serviceName strin
 	return false, nil
 }
 
-func ParseArn(arn *string) (*Service, error) {
+func parseArn(arn *string) (*Service, error) {
 	splitStr := strings.Split(*arn, "service/")
 	if len(splitStr) != 2 {
 		return nil, errors.New("illegal arn string")

--- a/lib/ecs_test.go
+++ b/lib/ecs_test.go
@@ -1,0 +1,152 @@
+package lib
+
+import (
+	_ "fmt"
+	"testing"
+
+	ecssdk "github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+)
+
+func TestListServices(t *testing.T) {
+	ecs := newMockedECS()
+	res, _ := ecs.ListServices(&ecssdk.ListServicesInput{})
+	t.Log(res)
+	for i, arn := range res.ServiceArns {
+		if *testServiceArns[i] != *arn {
+			t.Fatalf("Expected: %s, Got: %s", *testServiceArns[i], *arn)
+		}
+	}
+}
+
+func TestUpsertService(t *testing.T) {
+	// 存在するサービスは Update
+	existingSvcName := "some-service-a"
+	existingSvc := &ecssdk.CreateServiceInput{ServiceName: &existingSvcName}
+	{
+		ecs, called := updateServiceShouldCalledWith(t, "some-service-a")
+		ecs.UpsertService(existingSvc)
+		if !*called {
+			t.Fatalf("UpdateService should called")
+		}
+	}
+	createServiceShouldNotCalled(t).UpsertService(existingSvc)
+
+	// 存在しないサービスは Create
+	newSvcName := "some-service-d"
+	newSvc := &ecssdk.CreateServiceInput{ServiceName: &newSvcName}
+	{
+		ecs, called := createServiceShouldCalledWith(t, "some-service-d")
+		ecs.UpsertService(newSvc)
+		if !*called {
+			t.Fatalf("UpdateService should called")
+		}
+	}
+	updateServiceShouldNotCalled(t).UpsertService(newSvc)
+}
+
+type mockedECS struct {
+	ecsiface.ECSAPI
+	listServicesOutput *ecssdk.ListServicesOutput
+	createService      func(*ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error)
+	updateService      func(*ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error)
+}
+
+func (m mockedECS) CreateService(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
+	m.createService(in)
+	return nil, nil
+}
+
+func (m mockedECS) UpdateService(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
+	m.updateService(in)
+	return nil, nil
+}
+
+func (m mockedECS) ListServicesPages(in *ecssdk.ListServicesInput, f func(*ecssdk.ListServicesOutput, bool) bool) error {
+	f(m.listServicesOutput, true)
+	return nil
+}
+
+func newMockedECS() *ECS {
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService:      emptyCreateService,
+		updateService:      emptyUpdateService,
+	}
+	return &ECS{svc: svc}
+}
+
+func createServiceShouldCalledWith(t *testing.T, name string) (*ECS, *bool) {
+	called := false
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService: func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
+			called = true
+			if *in.ServiceName != name {
+				t.Fatalf("CreateService should called with %s", name)
+			}
+			return nil, nil
+		},
+		updateService: emptyUpdateService,
+	}
+	return &ECS{svc: svc}, &called
+}
+
+func updateServiceShouldCalledWith(t *testing.T, name string) (*ECS, *bool) {
+	called := false
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService:      emptyCreateService,
+		updateService: func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
+			called = true
+			if *in.Service != name {
+				t.Fatalf("UpdateService should called with %s", name)
+			}
+			return nil, nil
+		},
+	}
+	return &ECS{svc: svc}, &called
+}
+
+func createServiceShouldNotCalled(t *testing.T) *ECS {
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService: func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
+			t.Fatalf("CreateService should not called")
+			return nil, nil
+		},
+		updateService: emptyUpdateService,
+	}
+	return &ECS{svc: svc}
+}
+
+func updateServiceShouldNotCalled(t *testing.T) *ECS {
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService:      emptyCreateService,
+		updateService: func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
+			t.Fatalf("UpdateService should not called")
+			return nil, nil
+		},
+	}
+	return &ECS{svc: svc}
+}
+
+var emptyUpdateService = func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
+	return nil, nil
+}
+var emptyCreateService = func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
+	return nil, nil
+}
+
+// 既存サービスのモック
+var testServiceArns = make([]*string, 3)
+
+func init() {
+	s0 := "arn:aws:ecs:xx-someregion-1:01234567890123:service/some-service-a"
+	s1 := "arn:aws:ecs:xx-someregion-1:01234567890123:service/some-service-b"
+	s2 := "arn:aws:ecs:xx-someregion-1:01234567890123:service/some-service-c"
+	testServiceArns[0] = &s0
+	testServiceArns[1] = &s1
+	testServiceArns[2] = &s2
+}

--- a/lib/ecs_test.go
+++ b/lib/ecs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestListServices(t *testing.T) {
-	ecs := newMockedECS()
+	ecs, _ := mockECS()
 	res, _ := ecs.ListServices(&ecssdk.ListServicesInput{})
 	t.Log(res)
 	for i, arn := range res.ServiceArns {
@@ -20,29 +20,56 @@ func TestListServices(t *testing.T) {
 }
 
 func TestUpsertService(t *testing.T) {
-	// 存在するサービスは Update
-	existingSvcName := "some-service-a"
-	existingSvc := &ecssdk.CreateServiceInput{ServiceName: &existingSvcName}
+	// 存在するサービスは Update が呼ばれる
 	{
-		ecs, called := updateServiceShouldCalledWith(t, "some-service-a")
-		ecs.UpsertService(existingSvc)
-		if !*called {
-			t.Fatalf("UpdateService should called")
+		svcName := "some-service-a"
+		svc := &ecssdk.CreateServiceInput{ServiceName: &svcName}
+		ecs, fnArgs := mockECS()
+		ecs.UpsertService(svc)
+		if *fnArgs.UpdateServiceInput.Service != svcName {
+			t.Log(*fnArgs.UpdateServiceInput.Service)
+			t.Fatalf("UpdateService should be called with %s", svcName)
+		}
+		if fnArgs.CreateServiceInput != nil {
+			t.Fatalf("CreateService should not be called")
 		}
 	}
-	createServiceShouldNotCalled(t).UpsertService(existingSvc)
 
-	// 存在しないサービスは Create
-	newSvcName := "some-service-d"
-	newSvc := &ecssdk.CreateServiceInput{ServiceName: &newSvcName}
+	// 存在しないサービスは Create が呼ばれる
 	{
-		ecs, called := createServiceShouldCalledWith(t, "some-service-d")
-		ecs.UpsertService(newSvc)
-		if !*called {
-			t.Fatalf("UpdateService should called")
+		svcName := "some-service-d"
+		svc := &ecssdk.CreateServiceInput{ServiceName: &svcName}
+		ecs, fnArgs := mockECS()
+		ecs.UpsertService(svc)
+		if *fnArgs.CreateServiceInput.ServiceName != svcName {
+			t.Log(*fnArgs.CreateServiceInput.ServiceName)
+			t.Fatalf("CreateService should be called with %s", svcName)
+		}
+		if fnArgs.UpdateServiceInput != nil {
+			t.Fatalf("UpdateService should not be called")
 		}
 	}
-	updateServiceShouldNotCalled(t).UpsertService(newSvc)
+}
+
+type mockedFnArgs struct {
+	CreateServiceInput *ecssdk.CreateServiceInput
+	UpdateServiceInput *ecssdk.UpdateServiceInput
+}
+
+func mockECS() (*ECS, *mockedFnArgs) {
+	fnArgs := mockedFnArgs{CreateServiceInput: nil, UpdateServiceInput: nil}
+	svc := &mockedECS{
+		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
+		createService: func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
+			fnArgs = mockedFnArgs{CreateServiceInput: in, UpdateServiceInput: fnArgs.UpdateServiceInput}
+			return nil, nil
+		},
+		updateService: func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
+			fnArgs = mockedFnArgs{CreateServiceInput: fnArgs.CreateServiceInput, UpdateServiceInput: in}
+			return nil, nil
+		},
+	}
+	return &ECS{svc: svc}, &fnArgs
 }
 
 type mockedECS struct {
@@ -65,78 +92,6 @@ func (m mockedECS) UpdateService(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateS
 func (m mockedECS) ListServicesPages(in *ecssdk.ListServicesInput, f func(*ecssdk.ListServicesOutput, bool) bool) error {
 	f(m.listServicesOutput, true)
 	return nil
-}
-
-func newMockedECS() *ECS {
-	svc := &mockedECS{
-		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
-		createService:      emptyCreateService,
-		updateService:      emptyUpdateService,
-	}
-	return &ECS{svc: svc}
-}
-
-func createServiceShouldCalledWith(t *testing.T, name string) (*ECS, *bool) {
-	called := false
-	svc := &mockedECS{
-		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
-		createService: func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
-			called = true
-			if *in.ServiceName != name {
-				t.Fatalf("CreateService should called with %s", name)
-			}
-			return nil, nil
-		},
-		updateService: emptyUpdateService,
-	}
-	return &ECS{svc: svc}, &called
-}
-
-func updateServiceShouldCalledWith(t *testing.T, name string) (*ECS, *bool) {
-	called := false
-	svc := &mockedECS{
-		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
-		createService:      emptyCreateService,
-		updateService: func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
-			called = true
-			if *in.Service != name {
-				t.Fatalf("UpdateService should called with %s", name)
-			}
-			return nil, nil
-		},
-	}
-	return &ECS{svc: svc}, &called
-}
-
-func createServiceShouldNotCalled(t *testing.T) *ECS {
-	svc := &mockedECS{
-		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
-		createService: func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
-			t.Fatalf("CreateService should not called")
-			return nil, nil
-		},
-		updateService: emptyUpdateService,
-	}
-	return &ECS{svc: svc}
-}
-
-func updateServiceShouldNotCalled(t *testing.T) *ECS {
-	svc := &mockedECS{
-		listServicesOutput: &ecssdk.ListServicesOutput{ServiceArns: testServiceArns},
-		createService:      emptyCreateService,
-		updateService: func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
-			t.Fatalf("UpdateService should not called")
-			return nil, nil
-		},
-	}
-	return &ECS{svc: svc}
-}
-
-var emptyUpdateService = func(in *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
-	return nil, nil
-}
-var emptyCreateService = func(in *ecssdk.CreateServiceInput) (*ecssdk.CreateServiceOutput, error) {
-	return nil, nil
 }
 
 // 既存サービスのモック

--- a/lib/iface/ecs.go
+++ b/lib/iface/ecs.go
@@ -1,0 +1,10 @@
+package iface
+
+import (
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+type ECSAPI interface {
+	RegisterTaskDefinition(*ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
+	UpsertService(*ecs.CreateServiceInput) (interface{}, error)
+}


### PR DESCRIPTION
# 目的

- Service 無しで TaskDefinition のみの更新ができるように
- ECSまわりのテストを追加

# やったこと

- テスタブルな構成にリファクタリング
    - 参考: https://aws.amazon.com/jp/blogs/developer/mocking-out-then-aws-sdk-for-go-for-unit-testing/
- deploy 時に ELB を作成する機能は一旦無効化
    - テスタブルでない
    - うまく動いてない気がする

# 参考

階層構造はもともときれいだったので変更してません

- `lib/` は aws-sdk を抽象化
- `api/` は `lib/` の抽象化で, `subcmd/` に対応したインタフェース

![img_0243](https://cloud.githubusercontent.com/assets/3267290/26212303/16ab3dec-3c30-11e7-8140-e9fca7b5a083.jpg)
