### PR TITLE
コマンドライン引数にregionを指定しても反映されないバグを修正

### DIFF
--- a/subcmd/deploy/deploy.go
+++ b/subcmd/deploy/deploy.go
@@ -171,19 +171,26 @@ func (d *DeployCommand) parseArgs(args []string) (helpString string) {
 		d.file = f
 	}
 
-	var awsConfig = aws.Config{}
-
 	if *d.awsAccessKeyID != "" && *d.awsSecretKeyID != "" && *d.profile == "" {
-		awsConfig.Credentials = credentials.NewStaticCredentials(*d.awsAccessKeyID, *d.awsSecretKeyID, "")
-		awsConfig.Region = d.region
-	}
+		d.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Config: aws.Config{
+				Credentials: credentials.NewStaticCredentials(*d.awsAccessKeyID, *d.awsSecretKeyID, ""),
+				Region:      d.region,
+			},
+		}))
+	} else {
+		d.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Profile:                 *d.profile,
+		}))
 
-	d.sess = session.Must(session.NewSessionWithOptions(session.Options{
-		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-		SharedConfigState:       session.SharedConfigEnable,
-		Profile:                 *d.profile,
-		Config:                  awsConfig,
-	}))
+		if d.region != nil && *d.region != "" {
+			d.sess.Config.Region = d.region
+		}
+	}
 
 	return
 }

--- a/subcmd/vault/decrypt/decrypt.go
+++ b/subcmd/vault/decrypt/decrypt.go
@@ -55,19 +55,26 @@ func (d *DecryptCommand) parseArgs(args []string) (helpString string) {
 		d.file = f
 	}
 
-	var awsConfig = aws.Config{}
-
 	if *d.awsAccessKeyID != "" && *d.awsSecretKeyID != "" && *d.profile == "" {
-		awsConfig.Credentials = credentials.NewStaticCredentials(*d.awsAccessKeyID, *d.awsSecretKeyID, "")
-		awsConfig.Region = d.region
-	}
+		d.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Config: aws.Config{
+				Credentials: credentials.NewStaticCredentials(*d.awsAccessKeyID, *d.awsSecretKeyID, ""),
+				Region:      d.region,
+			},
+		}))
+	} else {
+		d.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Profile:                 *d.profile,
+		}))
 
-	d.sess = session.Must(session.NewSessionWithOptions(session.Options{
-		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-		SharedConfigState:       session.SharedConfigEnable,
-		Profile:                 *d.profile,
-		Config:                  awsConfig,
-	}))
+		if d.region != nil && *d.region != "" {
+			d.sess.Config.Region = d.region
+		}
+	}
 
 	return
 }

--- a/subcmd/vault/edit/edit.go
+++ b/subcmd/vault/edit/edit.go
@@ -71,19 +71,26 @@ func (e *EditCommand) parseArgs(args []string) (helpString string) {
 		e.file = f
 	}
 
-	var awsConfig = aws.Config{}
-
 	if *e.awsAccessKeyID != "" && *e.awsSecretKeyID != "" && *e.profile == "" {
-		awsConfig.Credentials = credentials.NewStaticCredentials(*e.awsAccessKeyID, *e.awsSecretKeyID, "")
-		awsConfig.Region = e.region
-	}
+		e.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Config: aws.Config{
+				Credentials: credentials.NewStaticCredentials(*e.awsAccessKeyID, *e.awsSecretKeyID, ""),
+				Region:      e.region,
+			},
+		}))
+	} else {
+		e.sess = session.Must(session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+			Profile:                 *e.profile,
+		}))
 
-	e.sess = session.Must(session.NewSessionWithOptions(session.Options{
-		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-		SharedConfigState:       session.SharedConfigEnable,
-		Profile:                 *e.profile,
-		Config:                  awsConfig,
-	}))
+		if e.region != nil && *e.region != "" {
+			e.sess.Config.Region = e.region
+		}
+	}
 
 	return
 }


### PR DESCRIPTION
# やったこと
profile名が指定されているときに `-region` で変数を渡してもregion情報が反映されなかったので修正した
`~/.aws/credentials` , `~./aws/config` を読み込んだあとにregionを上書きする

fix #69 